### PR TITLE
Configure site for GitHub Pages deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source "https://rubygems.org"
-gemspec
+
+group :jekyll_plugins do
+  gem "github-pages", "~> #{ENV['PAGES_GEM_VERSION']}", require: false
+  gem "jekyll-include-cache"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@
 # https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/#installing-the-theme
 
 # theme                  : "minimal-mistakes-jekyll"
-# remote_theme           : "mmistakes/minimal-mistakes"
+remote_theme             : "mmistakes/minimal-mistakes@4.27.0"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings


### PR DESCRIPTION
This commit makes the necessary adjustments to deploy the Jekyll site correctly on GitHub Pages.

Key changes:
- Updated `Gemfile` to include `github-pages` and `jekyll-include-cache` gems, using `ENV['PAGES_GEM_VERSION']` for compatibility with GitHub Pages build environment.
- Modified `_config.yml` to use `remote_theme: mmistakes/minimal-mistakes@4.27.0`. This ensures a stable version of the theme is used.
- Verified that `url`, `baseurl`, and `repository` settings in `_config.yml` are appropriate for a kookas.github.io user page.
- Confirmed `jekyll-include-cache` is listed in the plugins within `_config.yml`.
- Ensured `.gitignore` includes `Gemfile.lock`.

After these changes are merged, the site should build and deploy successfully via GitHub Actions on the kookas.github.io domain. Remember to check your repository settings on GitHub to ensure Pages is configured to deploy from the correct branch (main or master) and root folder.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - Read the contributing document at https://github.com/mmistakes/minimal-mistakes#contributing
-->

<!--
  Choose one of the following by uncommenting it:
-->

<!-- This is a bug fix. -->
<!-- This is an enhancement or feature. -->
<!-- This is a documentation change. -->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?
-->

<!--
  Please confirm that you want to submit this Pull Request to Minimal Mistakes, the free Jekyll theme by Michael Rose, by deleting this comment block.
-->
